### PR TITLE
Refactoring the cve-parser

### DIFF
--- a/cve-parser.py
+++ b/cve-parser.py
@@ -41,13 +41,18 @@ display_args.add_argument('-st', '--status', action='store_true', help='Display 
 display_args.add_argument('-l', '--link', action='store_true', help='Display https link to the CVE issue page')
 
 # Sorting arguments
-sorting_args = parser.add_mutually_exclusive_group(required=False)
+# NOTE: If new arguments are added, they should also be added to the manual check of mutual exclusivity below
+sorting_args = parser.add_argument_group('Sorting', 'Options to sort the results. Only one can be selected')
 sorting_args.add_argument('-sn', '--sort-package-name', action='store_true', help='Sort the results by package name')
 sorting_args.add_argument('-sc', '--sort-cve-id', action='store_true', help='Sort the results by CVE id')
 sorting_args.add_argument('-ss2', '--sort-cvss-score-v2', action='store_true', help='Sort the results by CVSS v2 score')
 sorting_args.add_argument('-ss3', '--sort-cvss-score-v3', action='store_true', help='Sort the results by CVSS v3 score')
 
 args = parser.parse_args()
+
+if sum([args.sort_cvss_score_v2, args.sort_cvss_score_v3,args.sort_package_name, args.sort_cve_id]) > 1:
+    print("Only one sorting option can be selected")
+    exit(1)
 
 print_list = []
 if args.package_name:

--- a/cve-parser.py
+++ b/cve-parser.py
@@ -2,14 +2,6 @@ import json
 import argparse
 from operator import itemgetter
 
-def should_print(args, issue):
-    if args.unpatched_cves and issue['status'] == "Unpatched":
-        return True
-    if args.patched_cves and issue['status'] == "Patched":
-        return True
-    if args.ignored_cves and issue['status'] == "Ignored":
-        return True
-    return False
 
 cve_id_tuple = ("{: <17}", "id")
 score_v2_tuple = ("{: <8}", "scorev2")
@@ -19,103 +11,156 @@ version_tuple = ("{: <10}", "version")
 link_tuple = ("{: <50}", "link")
 status_tuple = ("{: <10}", "status")
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-f', '--filename', required=True, help='Path to the json file containing the CVE report (required)')
-parser.add_argument('-e', '--extra-stats', action='store_true', help='Print extra stats like total number of issues shown, and hopefully more in the future')
-parser.add_argument('-he', '--header', action='store_true', help='Print header at the top of output')
 
-# Filtering arguments
-filter_args = parser.add_argument_group('Filters', 'Options to select the displayed issues (default: -u)')
-filter_args.add_argument('-u', '--unpatched-cves', action='store_true', help='Show unpatched CVEs')
-filter_args.add_argument('-p', '--patched-cves', action='store_true', help='Show patched CVEs')
-filter_args.add_argument('-i', '--ignored-cves', action='store_true', help='Show ignored')
+def initialize_argument_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--filename', required=True, help='Path to the json file containing the CVE report (required)')
+    parser.add_argument('-e', '--extra-stats', action='store_true', help='Print extra stats like total number of issues shown, and hopefully more in the future')
+    parser.add_argument('-he', '--header', action='store_true', help='Print header at the top of output')
 
-# Display arguments
-display_args = parser.add_argument_group('Display', 'Options to select the displayed fields of CVE issues (default: -n -c -s2 -s3 -st -l)')
-display_args.add_argument('-n', '--package-name', action='store_true', help='Display package name containing CVE')
-display_args.add_argument('-v', '--package-version', action='store_true', help='Display package version containing CVE')
-display_args.add_argument('-c', '--cve-id', action='store_true', help='Display CVE id')
-display_args.add_argument('-s2', '--cvss-score-v2', action='store_true', help='Display CVSS v2 score')
-display_args.add_argument('-s3', '--cvss-score-v3', action='store_true', help='Display CVSS v3 score')
-display_args.add_argument('-st', '--status', action='store_true', help='Display CVE status in the system')
-display_args.add_argument('-l', '--link', action='store_true', help='Display https link to the CVE issue page')
+    # Filtering arguments
+    filter_args = parser.add_argument_group('Filters', 'Options to select the displayed issues (default: -u)')
+    filter_args.add_argument('-u', '--unpatched-cves', action='store_true', help='Show unpatched CVEs')
+    filter_args.add_argument('-p', '--patched-cves', action='store_true', help='Show patched CVEs')
+    filter_args.add_argument('-i', '--ignored-cves', action='store_true', help='Show ignored')
 
-# Sorting arguments
-# NOTE: If new arguments are added, they should also be added to the manual check of mutual exclusivity below
-sorting_args = parser.add_argument_group('Sorting', 'Options to sort the results. Only one can be selected')
-sorting_args.add_argument('-sn', '--sort-package-name', action='store_true', help='Sort the results by package name')
-sorting_args.add_argument('-sc', '--sort-cve-id', action='store_true', help='Sort the results by CVE id')
-sorting_args.add_argument('-ss2', '--sort-cvss-score-v2', action='store_true', help='Sort the results by CVSS v2 score')
-sorting_args.add_argument('-ss3', '--sort-cvss-score-v3', action='store_true', help='Sort the results by CVSS v3 score')
+    # Display arguments
+    display_args = parser.add_argument_group('Display', 'Options to select the displayed fields of CVE issues (default: -n -c -s2 -s3 -st -l)')
+    display_args.add_argument('-n', '--package-name', action='store_true', help='Display package name containing CVE')
+    display_args.add_argument('-v', '--package-version', action='store_true', help='Display package version containing CVE')
+    display_args.add_argument('-c', '--cve-id', action='store_true', help='Display CVE id')
+    display_args.add_argument('-s2', '--cvss-score-v2', action='store_true', help='Display CVSS v2 score')
+    display_args.add_argument('-s3', '--cvss-score-v3', action='store_true', help='Display CVSS v3 score')
+    display_args.add_argument('-st', '--status', action='store_true', help='Display CVE status in the system')
+    display_args.add_argument('-l', '--link', action='store_true', help='Display https link to the CVE issue page')
 
-args = parser.parse_args()
+    # Sorting arguments
+    # NOTE: If new arguments are added, they should also be added to the manual check of mutual exclusivity check in parse_arguments
+    sorting_args = parser.add_argument_group('Sorting', 'Options to sort the results. Only one can be selected')
+    sorting_args.add_argument('-sn', '--sort-package-name', action='store_true', help='Sort the results by package name')
+    sorting_args.add_argument('-sc', '--sort-cve-id', action='store_true', help='Sort the results by CVE id')
+    sorting_args.add_argument('-ss2', '--sort-cvss-score-v2', action='store_true', help='Sort the results by CVSS v2 score')
+    sorting_args.add_argument('-ss3', '--sort-cvss-score-v3', action='store_true', help='Sort the results by CVSS v3 score')
+    return parser
 
-if sum([args.sort_cvss_score_v2, args.sort_cvss_score_v3,args.sort_package_name, args.sort_cve_id]) > 1:
-    print("Only one sorting option can be selected")
-    exit(1)
 
-print_list = []
-if args.package_name:
-    print_list.append(name_tuple)
-if args.package_version:
-    print_list.append(version_tuple)
-if args.cve_id:
-    print_list.append(cve_id_tuple)
-if args.cvss_score_v2:
-    print_list.append(score_v2_tuple)
-if args.cvss_score_v3:
-    print_list.append(score_v3_tuple)
-if args.status:
-    print_list.append(status_tuple)
-if args.link:
-    print_list.append(link_tuple)
+def parse_arguments(parser):
+    args = parser.parse_args()
 
-if len(print_list) == 0:
-    print_list = [name_tuple, cve_id_tuple, score_v2_tuple, score_v3_tuple, status_tuple, link_tuple]
+    if sum([args.sort_cvss_score_v2, args.sort_cvss_score_v3,args.sort_package_name, args.sort_cve_id]) > 1:
+        print("Only one sorting option can be selected")
+        return None
 
-if not args.unpatched_cves and not args.patched_cves and not args.ignored_cves:
-    args.unpatched_cves = True
+    if not args.unpatched_cves and not args.patched_cves and not args.ignored_cves:
+        args.unpatched_cves = True
 
-f = open(args.filename)
-  
-data = json.load(f)
+    return args
 
-issue_list = []
 
-for i in data['package']:
-    for j in i['issue']:
-        j['scorev2'] = float(j['scorev2'])
-        j['scorev3'] = float(j['scorev3'])
-        # Add package name and version to the issue
-        j['name'] = i['name']
-        j['version'] = i['version']
-        issue_list.append(j)
+def create_print_list(args):
+    print_list = []
+    if args.package_name:
+        print_list.append(name_tuple)
+    if args.package_version:
+        print_list.append(version_tuple)
+    if args.cve_id:
+        print_list.append(cve_id_tuple)
+    if args.cvss_score_v2:
+        print_list.append(score_v2_tuple)
+    if args.cvss_score_v3:
+        print_list.append(score_v3_tuple)
+    if args.status:
+        print_list.append(status_tuple)
+    if args.link:
+        print_list.append(link_tuple)
 
-if args.sort_cvss_score_v2:
-    issue_list.sort(key=itemgetter('scorev2'), reverse=True)
-elif args.sort_cvss_score_v3:
-    issue_list.sort(key=itemgetter('scorev3'), reverse=True)
-elif args.sort_package_name:
-    issue_list.sort(key=itemgetter('name'), reverse=False)
-elif args.sort_cve_id:
-    issue_list.sort(key=itemgetter('id'), reverse=True)
+    if len(print_list) == 0:
+        print_list = [name_tuple, cve_id_tuple, score_v2_tuple, score_v3_tuple, status_tuple, link_tuple]
 
-if args.header:
-    for print_item in print_list:
-        print(print_item[0].format(print_item[1]), end=" ")
-    print("")
+    return print_list
 
-total_displayed_issues = 0
-for issue in issue_list:
-    if should_print(args, issue):
+
+def create_issue_list(args, data):
+    issue_list = []
+
+    for i in data['package']:
+        for j in i['issue']:
+            j['scorev2'] = float(j['scorev2'])
+            j['scorev3'] = float(j['scorev3'])
+            # Add package name and version to the issue
+            j['name'] = i['name']
+            j['version'] = i['version']
+            issue_list.append(j)
+
+    if args.sort_cvss_score_v2:
+        issue_list.sort(key=itemgetter('scorev2'), reverse=True)
+    elif args.sort_cvss_score_v3:
+        issue_list.sort(key=itemgetter('scorev3'), reverse=True)
+    elif args.sort_package_name:
+        issue_list.sort(key=itemgetter('name'), reverse=False)
+    elif args.sort_cve_id:
+        issue_list.sort(key=itemgetter('id'), reverse=True)
+
+    return issue_list
+
+
+def create_issue_filter(args):
+    issue_filter = {}
+    issue_filter['unpatched_cves'] = args.unpatched_cves
+    issue_filter['patched_cves'] = args.patched_cves
+    issue_filter['ignored_cves'] = args.ignored_cves
+
+    return issue_filter
+
+
+def should_print(issue_filter, issue):
+    if issue_filter['unpatched_cves'] and issue['status'] == "Unpatched":
+        return True
+    if issue_filter['patched_cves'] and issue['status'] == "Patched":
+        return True
+    if issue_filter['ignored_cves'] and issue['status'] == "Ignored":
+        return True
+    return False
+
+
+def print_issues(header, extra_stats, print_list, issue_list, issue_filter):
+    if header:
         for print_item in print_list:
-            print(print_item[0].format(issue[print_item[1]]), end=" ")
+            print(print_item[0].format(print_item[1]), end=" ")
         print("")
-        total_displayed_issues += 1
 
-if args.extra_stats:
-    print("")
-    print("Extra stats:")
-    print("Total displayed issues: {}".format(total_displayed_issues))
+    total_displayed_issues = 0
+    for issue in issue_list:
+        if should_print(issue_filter, issue):
+            for print_item in print_list:
+                print(print_item[0].format(issue[print_item[1]]), end=" ")
+            print("")
+            total_displayed_issues += 1
 
-f.close()
+    if extra_stats:
+        print("")
+        print("Extra stats:")
+        print("Total displayed issues: {}".format(total_displayed_issues))
+
+
+def main():
+    parser = initialize_argument_parser()
+    args = parse_arguments(parser)
+
+    if args is None:
+        exit(1)
+
+    print_list = create_print_list(args)
+
+    f = open(args.filename)
+    data = json.load(f)
+
+    issue_list = create_issue_list(args, data)
+    issue_filter = create_issue_filter(args)
+    print_issues(args.header, args.extra_stats, print_list, issue_list, issue_filter)
+
+    f.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Refactor the CVE parser from a single Python file into a "proper" script with multiple functions and `main()` call. This should allow better maintainability of the project
- Don't use `add_mutually_exclusive_group` for sorting arguments. Mutually exclusive groups don't seem to allow setting topic and description, meaning that the `--help` of the program becomes messy to look at